### PR TITLE
C++ compatibility fix

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -1,6 +1,10 @@
 #include <stdlib.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct pico_hash;
 typedef struct pico_hash pico_hash;
 
@@ -27,3 +31,7 @@ int pico_hash_rem (pico_hash* table, const char* key);
 // table: pointer to the hash table
 // key: the key of the value to retrieve
 void* pico_hash_get (pico_hash* table, const char* key);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,3 +1,6 @@
+#ifndef PICO_HASH_H
+#define PICO_HASH_H
+
 #include <stdlib.h>
 #include <stddef.h>
 
@@ -35,3 +38,5 @@ void* pico_hash_get (pico_hash* table, const char* key);
 #ifdef __cplusplus
 }
 #endif
+
+#endif // PICO_HASH_H

--- a/src/pico.c
+++ b/src/pico.c
@@ -373,6 +373,17 @@ void pico_output_draw_pixel (SDL_Point pos) {
     SDL_RenderDrawPoint(REN, X(pos.x,1), Y(pos.y,1) );
 }
 
+void pico_output_draw_pixels (const SDL_Point* apos, int count) {
+    SDL_Point *apos_fixed = malloc(count * sizeof(SDL_Point));
+    for (int i = 0; i < count; i++) {
+        apos_fixed[i].x = X(apos[i].x,1);
+        apos_fixed[i].y = Y(apos[i].y,1);
+    }
+
+    SDL_RenderDrawPoints(REN, apos_fixed, count);
+    free(apos_fixed);
+}
+
 void pico_output_draw_rect (SDL_Rect rect) {
     SDL_Rect out = {
         X(rect.x, rect.w),

--- a/src/pico.c
+++ b/src/pico.c
@@ -9,7 +9,7 @@
 #define MAX(x,y) ((x) > (y) ? (x) : (y))
 
 SDL_Window*         WIN;
-static SDL_Texture* TEX;
+//static SDL_Texture* TEX;
 static TTF_Font*    FNT = NULL;
 static int          FNT_H;
 static SDL_Point    CUR_CURSOR = {0,0};

--- a/src/pico.c
+++ b/src/pico.c
@@ -341,7 +341,7 @@ void _pico_output_draw_image_tex (SDL_Point pos, SDL_Texture* tex) {
     SDL_RenderCopy(REN, tex, &crp, &rct);
 }
 
-void _pico_output_draw_image_cache (SDL_Point pos, char* path, int cache) {
+void _pico_output_draw_image_cache (SDL_Point pos, const char* path, int cache) {
     SDL_Texture* tex = NULL;
     if (cache) {
         tex = pico_hash_get(_pico_hash, path);
@@ -361,7 +361,7 @@ void _pico_output_draw_image_cache (SDL_Point pos, char* path, int cache) {
     }
 }
 
-void pico_output_draw_image (SDL_Point pos, char* path) {
+void pico_output_draw_image (SDL_Point pos, const char* path) {
     _pico_output_draw_image_cache(pos, path, 1);
 }
 
@@ -413,7 +413,7 @@ void pico_output_draw_oval (SDL_Rect rect) {
     }
 }
 
-void pico_output_draw_text (SDL_Point pos, char* text) {
+void pico_output_draw_text (SDL_Point pos, const char* text) {
     uint8_t r, g, b;
     SDL_GetRenderDrawColor(REN, &r,&g,&b, NULL);
     pico_assert(FNT != NULL);
@@ -445,7 +445,7 @@ void pico_output_present (void) {
     WIN_Clear();
 }
 
-void _pico_output_sound_cache (char* path, int cache) {
+void _pico_output_sound_cache (const char* path, int cache) {
     Mix_Chunk* mix = NULL;
 
     if (cache) {
@@ -466,11 +466,11 @@ void _pico_output_sound_cache (char* path, int cache) {
     }
 }
 
-void pico_output_sound (char* path) {
+void pico_output_sound (const char* path) {
     _pico_output_sound_cache(path, 1);
 }
 
-void pico_output_write_aux (char* text, int isln) {
+void pico_output_write_aux (const char* text, int isln) {
     if (strlen(text) == 0) {
         if (isln) {
             CUR_CURSOR.x = S.cursor.x;
@@ -504,11 +504,11 @@ void pico_output_write_aux (char* text, int isln) {
     SDL_FreeSurface(sfc);
 }
 
-void pico_output_write (char* text) {
+void pico_output_write (const char* text) {
     pico_output_write_aux(text, 0);
 }
 
-void pico_output_writeln (char* text) {
+void pico_output_writeln (const char* text) {
     pico_output_write_aux(text, 1);
 }
 
@@ -517,7 +517,7 @@ void pico_output_writeln (char* text) {
 
 // GET
 
-SDL_Point pico_get_image_size (char* file) {
+SDL_Point pico_get_image_size (const char* file) {
     SDL_Texture* tex = IMG_LoadTexture(REN, file);
     pico_assert(tex != NULL);
     SDL_Point size;
@@ -585,7 +585,7 @@ void pico_set_pan (SDL_Point pos) {
     S.pan = pos;
 }
 
-void pico_set_font (char* file, int h) {
+void pico_set_font (const char* file, int h) {
     FNT_H = h;
     if (FNT != NULL) {
         TTF_CloseFont(FNT);
@@ -641,7 +641,7 @@ void pico_set_style (Pico_Style style) {
     S.style = style;
 }
 
-void pico_set_title (char* title) {
+void pico_set_title (const char* title) {
     SDL_SetWindowTitle(WIN, title);
 }
 

--- a/src/pico.c
+++ b/src/pico.c
@@ -200,7 +200,7 @@ int pico_event_from_sdl (SDL_Event* e, int xp) {
             break;
     }
 
-    if (xp == e->type) {
+    if (xp == (int)e->type) {
         // OK
     } else if (xp == SDL_ANY) {
         // MAYBE

--- a/src/pico.h
+++ b/src/pico.h
@@ -45,17 +45,18 @@ int  pico_input_event_ask     (SDL_Event* evt, int type);
 int  pico_input_event_timeout (SDL_Event* evt, int type, int timeout);
 
 // OUTPUT
-void pico_output_clear      (void);
-void pico_output_draw_image (SDL_Point pos, const char* path);
-void pico_output_draw_line  (SDL_Point p1, SDL_Point p2);
-void pico_output_draw_pixel (SDL_Point pos);
-void pico_output_draw_rect  (SDL_Rect rect);
-void pico_output_draw_oval  (SDL_Rect rect);
-void pico_output_draw_text  (SDL_Point pos, const char* text);
-void pico_output_present    (void);
-void pico_output_sound      (const char* path);
-void pico_output_write      (const char* text);
-void pico_output_writeln    (const char* text);
+void pico_output_clear       (void);
+void pico_output_draw_image  (SDL_Point pos, const char* path);
+void pico_output_draw_line   (SDL_Point p1, SDL_Point p2);
+void pico_output_draw_pixel  (SDL_Point pos);
+void pico_output_draw_pixels (const SDL_Point* apos, int count);
+void pico_output_draw_rect   (SDL_Rect rect);
+void pico_output_draw_oval   (SDL_Rect rect);
+void pico_output_draw_text   (SDL_Point pos, const char* text);
+void pico_output_present     (void);
+void pico_output_sound       (const char* path);
+void pico_output_write       (const char* text);
+void pico_output_writeln     (const char* text);
 
 void _pico_output_draw_image_cache (SDL_Point pos, const char* path, int cache);
 void _pico_output_sound_cache (const char* path, int cache);

--- a/src/pico.h
+++ b/src/pico.h
@@ -2,6 +2,10 @@
 #include <assert.h>
 #include <SDL2/SDL.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PICO_TITLE "pico-SDL"
 #define PICO_PHY_X 640
 #define PICO_PHY_Y 360
@@ -76,3 +80,7 @@ void pico_set_size_internal (SDL_Point log);
 void pico_set_show          (int on);
 void pico_set_style         (Pico_Style style);
 void pico_set_title         (char* title);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/pico.h
+++ b/src/pico.h
@@ -46,23 +46,23 @@ int  pico_input_event_timeout (SDL_Event* evt, int type, int timeout);
 
 // OUTPUT
 void pico_output_clear      (void);
-void pico_output_draw_image (SDL_Point pos, char* path);
+void pico_output_draw_image (SDL_Point pos, const char* path);
 void pico_output_draw_line  (SDL_Point p1, SDL_Point p2);
 void pico_output_draw_pixel (SDL_Point pos);
 void pico_output_draw_rect  (SDL_Rect rect);
 void pico_output_draw_oval  (SDL_Rect rect);
-void pico_output_draw_text  (SDL_Point pos, char* text);
+void pico_output_draw_text  (SDL_Point pos, const char* text);
 void pico_output_present    (void);
-void pico_output_sound      (char* path);
-void pico_output_write      (char* text);
-void pico_output_writeln    (char* text);
+void pico_output_sound      (const char* path);
+void pico_output_write      (const char* text);
+void pico_output_writeln    (const char* text);
 
-void _pico_output_draw_image_cache (SDL_Point pos, char* path, int cache);
-void _pico_output_sound_cache (char* path, int cache);
+void _pico_output_draw_image_cache (SDL_Point pos, const char* path, int cache);
+void _pico_output_sound_cache (const char* path, int cache);
 
 // STATE
 
-SDL_Point pico_get_image_size    (char* file);
+SDL_Point pico_get_image_size    (const char* file);
 SDL_Point pico_get_size          (void);
 SDL_Point pico_get_size_external (void);
 SDL_Point pico_get_size_internal (void);
@@ -72,7 +72,7 @@ void pico_set_anchor        (Pico_HAnchor h, Pico_VAnchor v);
 void pico_set_color_clear   (SDL_Color color);
 void pico_set_color_draw    (SDL_Color color);
 void pico_set_cursor        (SDL_Point pos);
-void pico_set_font          (char* file, int h);
+void pico_set_font          (const char* file, int h);
 void pico_set_grid          (int on);
 void pico_set_image_crop    (SDL_Rect crop);
 void pico_set_image_size    (SDL_Point size);
@@ -82,7 +82,7 @@ void pico_set_size_external (SDL_Point phy);
 void pico_set_size_internal (SDL_Point log);
 void pico_set_show          (int on);
 void pico_set_style         (Pico_Style style);
-void pico_set_title         (char* title);
+void pico_set_title         (const char* title);
 
 #ifdef __cplusplus
 }

--- a/src/pico.h
+++ b/src/pico.h
@@ -1,3 +1,6 @@
+#ifndef PICO_H
+#define PICO_H
+
 #include <stdio.h>
 #include <assert.h>
 #include <SDL2/SDL.h>
@@ -84,3 +87,6 @@ void pico_set_title         (char* title);
 #ifdef __cplusplus
 }
 #endif
+
+#endif // PICO_H
+


### PR DESCRIPTION
Compiling pico as C++ fails because C++ has more strict compilation rules. Specifically pointer type conversions. Compiling it as C and linking with C++ fails as well. I found out that adding the following to both src/pico.h and src/hash.h fixes the problem.

// includes

#ifdef __cplusplus
extern "C" {
#endif

// ...

#ifdef __cplusplus
}
#endif

With that, pico can be compiled as C and linked with C++.