### PR TITLE
Fix SDL window initialization issue

### DIFF
--- a/src/colors.h
+++ b/src/colors.h
@@ -1,0 +1,39 @@
+#ifndef PICO_COLORS_H
+#define PICO_COLORS_H
+
+#include "pico.h"
+
+/// @defgroup Predefined Colors
+/// @brief Predefined color constants for common colors.
+/// @{
+
+// Grayscale
+#define PICO_COLOR_BLACK   ((Pico_Color) {0, 0, 0})
+#define PICO_COLOR_WHITE   ((Pico_Color) {255, 255, 255})
+#define PICO_COLOR_GRAY    ((Pico_Color) {128, 128, 128})
+#define PICO_COLOR_SILVER  ((Pico_Color) {192, 192, 192})
+
+// Primary colors
+#define PICO_COLOR_RED     ((Pico_Color) {255, 0, 0})
+#define PICO_COLOR_GREEN   ((Pico_Color) {0, 255, 0})
+#define PICO_COLOR_BLUE    ((Pico_Color) {0, 0, 255})
+
+// Secondary colors
+#define PICO_COLOR_YELLOW  ((Pico_Color) {255, 255, 0})
+#define PICO_COLOR_CYAN    ((Pico_Color) {0, 255, 255})
+#define PICO_COLOR_MAGENTA ((Pico_Color) {255, 0, 255})
+
+// Common colors
+#define PICO_COLOR_ORANGE  ((Pico_Color) {255, 165, 0})
+#define PICO_COLOR_PURPLE  ((Pico_Color) {128, 0, 128})
+#define PICO_COLOR_PINK    ((Pico_Color) {255, 192, 203})
+#define PICO_COLOR_BROWN   ((Pico_Color) {165, 42, 42})
+#define PICO_COLOR_LIME    ((Pico_Color) {0, 255, 0})
+#define PICO_COLOR_TEAL    ((Pico_Color) {0, 128, 128})
+#define PICO_COLOR_NAVY    ((Pico_Color) {0, 0, 128})
+#define PICO_COLOR_MAROON  ((Pico_Color) {128, 0, 0})
+#define PICO_COLOR_OLIVE   ((Pico_Color) {128, 128, 0})
+
+/// @}
+
+#endif // PICO_COLORS_H

--- a/src/pico.c
+++ b/src/pico.c
@@ -144,6 +144,31 @@ int pico_vs_rect_rect_pct (Pico_Rect_Pct* r1, Pico_Rect_Pct* r2) {
     return pico_vs_rect_rect_raw(pico_cv_rect_pct_raw(r1), pico_cv_rect_pct_raw(r2));
 }
 
+Pico_Color pico_color_darker (Pico_Color color, int pct) {
+    if (pct < 0) {
+        return pico_color_lighter(color, -pct);
+    }
+    float factor = 1.0f - (pct / 100.0f);
+    if (factor < 0.0f) factor = 0.0f;
+    return (Pico_Color) {
+        (Uint8)(color.r * factor),
+        (Uint8)(color.g * factor),
+        (Uint8)(color.b * factor)
+    };
+}
+
+Pico_Color pico_color_lighter (Pico_Color color, int pct) {
+    if (pct < 0) {
+        return pico_color_darker(color, -pct);
+    }
+    float factor = pct / 100.0f;
+    return (Pico_Color) {
+        (Uint8)(color.r + (255 - color.r) * factor),
+        (Uint8)(color.g + (255 - color.g) * factor),
+        (Uint8)(color.b + (255 - color.b) * factor)
+    };
+}
+
 // INIT
 
 void pico_init (int on) {

--- a/src/pico.h
+++ b/src/pico.h
@@ -573,6 +573,20 @@ int pico_vs_rect_rect_raw (Pico_Rect r1, Pico_Rect r2);
 /// @sa pico_vs_rect_rect_raw
 int pico_vs_rect_rect_pct (Pico_Rect_Pct* r1, Pico_Rect_Pct* r2);
 
+/// @brief Makes a color darker by the specified percentage.
+/// @param color the original color
+/// @param pct percentage to darken (0-100); negative values lighten
+/// @return the darkened color
+/// @sa pico_color_lighter
+Pico_Color pico_color_darker (Pico_Color color, int pct);
+
+/// @brief Makes a color lighter by the specified percentage.
+/// @param color the original color
+/// @param pct percentage to lighten (0-100); negative values darken
+/// @return the lightened color
+/// @sa pico_color_darker
+Pico_Color pico_color_lighter (Pico_Color color, int pct);
+
 /// @}
 
 #ifdef __cplusplus

--- a/tst/colors.c
+++ b/tst/colors.c
@@ -1,0 +1,166 @@
+#include "pico.h"
+#include "../src/colors.h"
+#include "../check.h"
+
+int main (void) {
+    pico_init(1);
+    pico_set_title("Colors Test");
+    pico_set_view_raw(
+        -1,
+        &(Pico_Dim){640, 480},
+        NULL,
+        &(Pico_Dim){64, 48},
+        NULL,
+        NULL
+    );
+
+    {
+        puts("predefined colors");
+        pico_output_clear();
+
+        // Draw rectangles with predefined colors
+        float y = 0.1;
+        float h = 0.05;
+
+        pico_set_color_draw(PICO_COLOR_RED);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(PICO_COLOR_GREEN);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(PICO_COLOR_BLUE);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(PICO_COLOR_YELLOW);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(PICO_COLOR_CYAN);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(PICO_COLOR_MAGENTA);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(PICO_COLOR_ORANGE);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(PICO_COLOR_PURPLE);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(PICO_COLOR_PINK);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+
+        _pico_check("colors-01");
+    }
+
+    {
+        puts("darker function");
+        pico_output_clear();
+
+        Pico_Color base = PICO_COLOR_RED;
+        float y = 0.1;
+        float h = 0.08;
+
+        // Original color
+        pico_set_color_draw(base);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        // Progressively darker
+        pico_set_color_draw(pico_color_darker(base, 25));
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(pico_color_darker(base, 50));
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(pico_color_darker(base, 75));
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+
+        _pico_check("colors-02");
+    }
+
+    {
+        puts("lighter function");
+        pico_output_clear();
+
+        Pico_Color base = PICO_COLOR_BLUE;
+        float y = 0.1;
+        float h = 0.08;
+
+        // Original color
+        pico_set_color_draw(base);
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        // Progressively lighter
+        pico_set_color_draw(pico_color_lighter(base, 25));
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(pico_color_lighter(base, 50));
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+        y += h + 0.02;
+
+        pico_set_color_draw(pico_color_lighter(base, 75));
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.5, y, 0.8, h, PICO_ANCHOR_C, NULL});
+
+        _pico_check("colors-03");
+    }
+
+    {
+        puts("negative percentages");
+        pico_output_clear();
+
+        Pico_Color base = PICO_COLOR_GREEN;
+        float y = 0.15;
+        float h = 0.12;
+
+        // Using darker with negative (should lighten)
+        pico_set_color_draw(pico_color_darker(base, -50));
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.3, y, 0.35, h, PICO_ANCHOR_C, NULL});
+
+        // Using lighter with negative (should darken)
+        pico_set_color_draw(pico_color_lighter(base, -50));
+        pico_output_draw_rect_pct(&(Pico_Rect_Pct){0.7, y, 0.35, h, PICO_ANCHOR_C, NULL});
+
+        _pico_check("colors-04");
+    }
+
+    {
+        puts("color gradients");
+        pico_output_clear();
+
+        Pico_Color base = PICO_COLOR_ORANGE;
+        float x_start = 0.1;
+        float w = 0.05;
+        float h = 0.6;
+
+        // Gradient from dark to light
+        for (int i = 0; i <= 10; i++) {
+            int darkness = 90 - (i * 18);  // 90, 72, 54, 36, 18, 0, -18, -36, -54, -72, -90
+            pico_set_color_draw(pico_color_darker(base, darkness));
+            pico_output_draw_rect_pct(&(Pico_Rect_Pct){
+                x_start + (i * w),
+                0.5,
+                w,
+                h,
+                PICO_ANCHOR_C,
+                NULL
+            });
+        }
+
+        _pico_check("colors-05");
+    }
+
+    pico_init(0);
+    return 0;
+}


### PR DESCRIPTION
Implements feature request from issue #61:
- Add pico_color_darker() and pico_color_lighter() functions
- Both functions support negative percentages for reverse operation
- Create src/colors.h with predefined color constants (PICO_COLOR_RED, etc.)
- Add comprehensive test file tst/colors.c demonstrating color functionality