### PR TITLE
Add multi-font tests

### DIFF
--- a/tst/font.c
+++ b/tst/font.c
@@ -36,6 +36,42 @@ int main (void) {
         _pico_check("font-02");
     }
 
+    // non-default font (DejaVuSans)
+    pico_set_font("DejaVuSans.ttf");
+    {
+        pico_output_clear();
+        Pico_Rel_Rect r = {
+            '!', {10,10, 0,10}, PICO_ANCHOR_NW, NULL
+        };
+        pico_output_draw_text("hg - gh", &r);
+        _pico_check("font-03");
+    }
+
+    // switch back to default font
+    pico_set_font(NULL);
+    {
+        pico_output_clear();
+        Pico_Rel_Rect r = {
+            '!', {10,10, 0,10}, PICO_ANCHOR_NW, NULL
+        };
+        pico_output_draw_text("hg - gh", &r);
+        _pico_check("font-04");
+    }
+
+    // push/pop preserves font across switches
+    pico_set_font("DejaVuSans.ttf");
+    pico_push();
+    pico_set_font(NULL);
+    pico_pop();
+    {
+        pico_output_clear();
+        Pico_Rel_Rect r = {
+            '!', {10,10, 0,10}, PICO_ANCHOR_NW, NULL
+        };
+        pico_output_draw_text("hg - gh", &r);
+        _pico_check("font-05");
+    }
+
     pico_init(0);
     return 0;
 }


### PR DESCRIPTION
## Summary
- Extend `tst/font.c` with tests for switching between multiple fonts
- Test rendering with non-default font `DejaVuSans.ttf` (font-03)
- Test switching back to built-in default font (font-04)
- Test `pico_push/pop` preserves font across switches (font-05)

## Test plan
- [ ] Place `DejaVuSans.ttf` in `tst/`
- [ ] Run `make gen T=font` to generate assertion images (font-03..05)
- [ ] Run `make test T=font` to verify tests pass