### PR TITLE
Cache fonts in hash table with TTL-based GC

### DIFF
--- a/lua/pico.c
+++ b/lua/pico.c
@@ -614,6 +614,16 @@ static int l_get_image (lua_State* L) {
     return 1;
 }
 
+static int l_get_font (lua_State* L) {
+    const char* font = pico_get_font();
+    if (font == NULL) {
+        lua_pushnil(L);
+    } else {
+        lua_pushstring(L, font);
+    }
+    return 1;
+}
+
 static int l_get_layer (lua_State* L) {
     const char* name = pico_get_layer();
     if (name == NULL) {
@@ -800,6 +810,15 @@ static int l_get_mouse (lua_State* L) {
 static int l_set_alpha (lua_State* L) {
     int a = luaL_checkinteger(L, 1);
     pico_set_alpha(a);
+    return 0;
+}
+
+static int l_set_font (lua_State* L) {
+    const char* path = NULL;
+    if (lua_gettop(L) >= 1 && !lua_isnil(L, 1)) {
+        path = luaL_checkstring(L, 1);
+    }
+    pico_set_font(path);
     return 0;
 }
 
@@ -1333,6 +1352,7 @@ static const luaL_Reg ll_color[] = {
 ///////////////////////////////////////////////////////////////////////////////
 
 static const luaL_Reg ll_get[] = {
+    { "font",   l_get_font   },
     { "image",  l_get_image  },
     { "layer",  l_get_layer  },
     { "mouse",  l_get_mouse  },
@@ -1349,6 +1369,7 @@ static const luaL_Reg ll_set[] = {
     { "alpha",  l_set_alpha  },
     { "dim",    l_set_dim    },
     { "expert", l_set_expert },
+    { "font",   l_set_font   },
     { "layer",  l_set_layer  },
     { "style",  l_set_style  },
     { "view",   l_set_view   },


### PR DESCRIPTION
## Summary
- Add `PICO_KEY_FONT` resource type to hash table
- New `_font_get(path, height)` caches `TTF_Font*` objects (key: `/font/<path>/<height>`)
- Remove per-render `TTF_CloseFont()` from `_tex_text()` — GC handles cleanup via TTL
- Add `TTF_CloseFont()` to `_pico_hash_clean()` for font entries
- Add Lua bindings: `pico.set.font(path)` and `pico.get.font()`

## Test plan
- [ ] Run `make tests` to verify existing tests pass
- [ ] Verify font caching with valgrind (no leaks)
- [ ] Test Lua bindings: `pico.set.font("path.ttf")` / `pico.get.font()`