### PR TITLE
feat: add pico_warp_mouse to move cursor via logical coordinates (#110)

### DIFF
--- a/lua/pico.c
+++ b/lua/pico.c
@@ -939,8 +939,14 @@ static int l_set_layer (lua_State* L) {
 }
 
 static int l_set_mouse (lua_State* L) {
-    const char* s = luaL_checkstring(L, 1);
-    pico_set_mouse(s[0]);
+    if (lua_type(L, 1) == LUA_TSTRING) {
+        const char* s = lua_tostring(L, 1);
+        pico_set_mouse(s[0]);
+    } else {
+        luaL_checktype(L, 1, LUA_TTABLE);
+        Pico_Rel_Pos* pos = c_rel_pos(L, 1);
+        pico_warp_mouse(pos);
+    }
     return 0;
 }
 

--- a/lua/tst/mouse_warp.lua
+++ b/lua/tst/mouse_warp.lua
@@ -1,0 +1,52 @@
+require 'pico.check'
+
+pico.init(true)
+
+print("phy (500,500) -> log (50,50)")
+do
+    pico.set.window({title="Mouse Warp", dim={'!', w=500, h=500}})
+    pico.set.view({dim={'!', w=50, h=50}})
+
+    -- log (0,0) -> phy (0,0)
+    do
+        pico.set.mouse({'!', x=0, y=0, anchor='NW'})
+        pico.input.event(100)
+        local pos = pico.get.mouse()
+        assert(pos.x==0 and pos.y==0)
+    end
+
+    -- pct (0.5, 0.5) -> log (25,25) -> phy (250,250)
+    do
+        pico.set.mouse({'%', x=0.5, y=0.5, anchor='NW'})
+        pico.input.event(100)
+        local pos = pico.get.mouse('%')
+        assert(pos.x==0.5 and pos.y==0.5)
+        local pos_raw = pico.get.mouse('!')
+        assert(pos_raw.x==25 and pos_raw.y==25)
+    end
+end
+
+-- Zoom out: src = {-25, -25, 100, 100}
+-- centered 100x100 logical
+print("zoom out 2x")
+do
+    pico.set.view({source={'!', x=-25, y=-25, w=100, h=100, anchor='NW'}})
+
+    -- log (25, 25) -> phy (250, 250)
+    do
+        pico.set.mouse({'!', x=25, y=25, anchor='NW'})
+        pico.input.event(100)
+        local pos = pico.get.mouse()
+        assert(pos.x==25 and pos.y==25)
+    end
+
+    -- log (-25, -25) -> phy (0, 0)
+    do
+        pico.set.mouse({'!', x=-25, y=-25, anchor='NW'})
+        pico.input.event(100)
+        local pos = pico.get.mouse()
+        assert(pos.x==-25 and pos.y==-25)
+    end
+end
+
+pico.init(false)

--- a/src/pico.c
+++ b/src/pico.c
@@ -350,6 +350,17 @@ static SDL_FPoint _cv_phy_log (SDL_Point phy) {
     };
 }
 
+static SDL_Point _cv_log_phy (SDL_FPoint log) {
+    SDL_Rect dst = pico_cv_rect_rel_abs(&S.layer->view.dst, &(Pico_Abs_Rect){0, 0, S.win.dim.w, S.win.dim.h});
+    SDL_Rect src = pico_cv_rect_rel_abs(&S.layer->view.src, NULL);
+    float rx = (log.x - src.x) / (float)src.w;
+    float ry = (log.y - src.y) / (float)src.h;
+    return (SDL_Point) {
+        roundf(dst.x + rx*dst.w),
+        roundf(dst.y + ry*dst.h),
+    };
+}
+
 Pico_Abs_Dim pico_cv_dim_rel_abs (Pico_Rel_Dim* dim, Pico_Abs_Rect* base) {
     SDL_FDim df = _sdl_dim(dim, base, NULL);
     return _fi_dim(&df);
@@ -881,6 +892,16 @@ void pico_set_show (int on) {
 void pico_set_mouse (char mode) {
     assert((mode=='w' || mode=='!' || mode=='%' || mode=='#') && "invalid mouse mode");
     S.mouse = mode;
+}
+
+void pico_warp_mouse (Pico_Rel_Pos* pos) {
+    if (pos->mode == 'w') {
+        SDL_WarpMouseInWindow(G.win, (int)roundf(pos->x), (int)roundf(pos->y));
+    } else {
+        Pico_Abs_Pos log = pico_cv_pos_rel_abs(pos, NULL);
+        SDL_Point phy = _cv_log_phy((SDL_FPoint){log.x, log.y});
+        SDL_WarpMouseInWindow(G.win, phy.x, phy.y);
+    }
 }
 
 void pico_set_style (PICO_STYLE style) {

--- a/src/pico.h
+++ b/src/pico.h
@@ -519,6 +519,10 @@ void pico_set_show (int on);
 /// @param mode coordinate mode ('!' pixels, '%' percentage, '#' tiles, 'w' window)
 void pico_set_mouse (char mode);
 
+/// @brief Warps the mouse cursor to a point.
+/// @param pos target position (mode determines coordinates)
+void pico_warp_mouse (Pico_Rel_Pos* pos);
+
 /// @brief Sets the drawing style.
 /// @param style new style
 void pico_set_style (PICO_STYLE style);

--- a/tst/mouse.c
+++ b/tst/mouse.c
@@ -16,7 +16,7 @@ int main(void) {
 
         // phy (0,0) -> log (0,0)
         {
-            SDL_WarpMouseInWindow(pico_win, 0, 3);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {0, 3}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x==0 && pos.y==0.3f);
@@ -24,7 +24,7 @@ int main(void) {
 
         // phy (250,250) -> log (25,25)
         {
-            SDL_WarpMouseInWindow(pico_win, 250, 251);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {250, 251}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse('!');
             assert(pos.x==25 && pos.y==25.099998f);
@@ -32,7 +32,7 @@ int main(void) {
 
         // phy (490,490) -> log (49,49)
         {
-            SDL_WarpMouseInWindow(pico_win, 499, 490);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {499, 490}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x==49.900002f && pos.y==49);
@@ -49,7 +49,7 @@ int main(void) {
 
         // phy (250, 250) -> log (25,25)
         {
-            SDL_WarpMouseInWindow(pico_win, 250, 253);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {250, 253}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x==25 && pos.y==25.599998f);
@@ -57,7 +57,7 @@ int main(void) {
 
         // phy (0,0) -> log (-25,-25)
         {
-            SDL_WarpMouseInWindow(pico_win, 0, 0);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {0, 0}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x==-25 && pos.y==-25);
@@ -65,7 +65,7 @@ int main(void) {
 
         // phy (500,500) -> log (75,75)
         {
-            SDL_WarpMouseInWindow(pico_win, 495, 499);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {495, 499}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x==74 && pos.y==74.800003f);
@@ -82,7 +82,7 @@ int main(void) {
 
         // phy (0,0) -> log (20,20)
         {
-            SDL_WarpMouseInWindow(pico_win, 1, 2);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {1, 2}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x==20.02f && pos.y==20.040001f);
@@ -90,7 +90,7 @@ int main(void) {
 
         // phy center (250,250) -> log (25,25)
         {
-            SDL_WarpMouseInWindow(pico_win, 254, 251);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {254, 251}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x==25.08f && pos.y==25.02f);
@@ -98,7 +98,7 @@ int main(void) {
 
         // phy (500,500) -> log (30,30)
         {
-            SDL_WarpMouseInWindow(pico_win, 497, 498);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {497, 498}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x==29.940001f && pos.y==29.959999f);
@@ -115,7 +115,7 @@ int main(void) {
 
         // phy (0,0) -> log (25,25)
         {
-            SDL_WarpMouseInWindow(pico_win, 2, 1);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {2, 1}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x==25.1f && pos.y==25.049999f);
@@ -123,7 +123,7 @@ int main(void) {
 
         // phy (250,250) -> log (37,37)
         {
-            SDL_WarpMouseInWindow(pico_win, 253, 250);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {253, 250}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x==37.650002f && pos.y==37.5f);
@@ -138,7 +138,7 @@ int main(void) {
 
         // phy (250,250) -> pct (0.5,0.5)
         {
-            SDL_WarpMouseInWindow(pico_win, 250, 250);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {250, 250}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse('%');
             assert(pos.x==0.5 && pos.y==0.5);
@@ -146,7 +146,7 @@ int main(void) {
 
         // phy (0,0) -> pct (0,0)
         {
-            SDL_WarpMouseInWindow(pico_win, 0, 0);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {0, 0}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse('%');
             assert(pos.x==0.0 && pos.y==0.0);
@@ -164,7 +164,7 @@ int main(void) {
 
         // phy (0,0) -> raw (20,20) -> pct (0.4,0.4)
         {
-            SDL_WarpMouseInWindow(pico_win, 0, 0);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {0, 0}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x>0.39 && pos.x<0.41);
@@ -173,7 +173,7 @@ int main(void) {
 
         // phy (250,250) -> raw (25,25) -> pct (0.5,0.5)
         {
-            SDL_WarpMouseInWindow(pico_win, 250, 250);
+            pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {250, 250}, PICO_ANCHOR_NW, NULL });
             SDL_PumpEvents();
             Pico_Mouse pos = pico_get_mouse(0);
             assert(pos.x>0.49 && pos.x<0.51);

--- a/tst/mouse_warp.c
+++ b/tst/mouse_warp.c
@@ -1,0 +1,67 @@
+#include "pico.h"
+#include <SDL2/SDL.h>
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+
+extern SDL_Window* pico_win;
+
+int main(void) {
+    pico_init(1);
+
+    puts("phy (500,500) -> log (50,50)");
+    {
+        pico_set_window("Mouse Warp", -1, &(Pico_Rel_Dim){ '!', {500, 500}, NULL });
+        pico_set_view(-1, &(Pico_Rel_Dim){ '!', {50, 50}, NULL }, NULL, NULL, NULL, NULL, NULL, NULL);
+
+        // log (0,0) -> phy (0,0)
+        {
+            Pico_Rel_Pos p = {'!', {0, 0}, PICO_ANCHOR_NW, NULL};
+            pico_warp_mouse(&p);
+            SDL_PumpEvents();
+            Pico_Mouse pos = pico_get_mouse(0);
+            assert(pos.x==0 && pos.y==0);
+        }
+
+        // pct (0.5, 0.5) -> log (25,25) -> phy (250,250)
+        {
+            Pico_Rel_Pos p = {'%', {0.5, 0.5}, PICO_ANCHOR_NW, NULL};
+            pico_warp_mouse(&p);
+            SDL_PumpEvents();
+            Pico_Mouse pos = pico_get_mouse('%');
+            assert(pos.x==0.5 && pos.y==0.5);
+            Pico_Mouse pos_raw = pico_get_mouse('!');
+            assert(pos_raw.x==25 && pos_raw.y==25);
+        }
+    }
+
+    // Zoom out: src = {-25, -25, 100, 100}
+    // centered 100x100 logical
+    puts("zoom out 2x");
+    {
+        pico_set_view(-1, NULL, NULL, NULL,
+            &(Pico_Rel_Rect){ '!', {-25, -25, 100, 100}, PICO_ANCHOR_NW, NULL },
+            NULL, NULL, NULL);
+
+        // log (25, 25) -> phy (250, 250)
+        {
+            Pico_Rel_Pos p = {'!', {25, 25}, PICO_ANCHOR_NW, NULL};
+            pico_warp_mouse(&p);
+            SDL_PumpEvents();
+            Pico_Mouse pos = pico_get_mouse(0);
+            assert(pos.x==25 && pos.y==25);
+        }
+
+        // log (-25, -25) -> phy (0, 0)
+        {
+            Pico_Rel_Pos p = {'!', {-25, -25}, PICO_ANCHOR_NW, NULL};
+            pico_warp_mouse(&p);
+            SDL_PumpEvents();
+            Pico_Mouse pos = pico_get_mouse(0);
+            assert(pos.x==-25 && pos.y==-25);
+        }
+    }
+
+    pico_init(0);
+    return 0;
+}

--- a/tst/tiles.c
+++ b/tst/tiles.c
@@ -61,7 +61,7 @@ int main (void) {
     // phy (0,0) -> log (0,0) -> tile (1,1)
     {
         puts("mouse tile (1,1)");
-        SDL_WarpMouseInWindow(pico_win, 0, 0);
+        pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {0, 0}, PICO_ANCHOR_NW, NULL });
         SDL_PumpEvents();
         Pico_Mouse pos = pico_get_mouse(0);
         assert(pos.x==1 && pos.y==1);
@@ -71,7 +71,7 @@ int main (void) {
     // 160 phy / 16 log = 10x scale, so phy 40 = log 4
     {
         puts("mouse tile (2,2)");
-        SDL_WarpMouseInWindow(pico_win, 40, 40);
+        pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {40, 40}, PICO_ANCHOR_NW, NULL });
         SDL_PumpEvents();
         Pico_Mouse pos = pico_get_mouse(0);
         assert(pos.x==2 && pos.y==2);
@@ -80,7 +80,7 @@ int main (void) {
     // phy (80,120) -> log (8,12) -> tile (3,4)
     {
         puts("mouse tile (3,4)");
-        SDL_WarpMouseInWindow(pico_win, 80, 120);
+        pico_warp_mouse(&(Pico_Rel_Pos){ 'w', {80, 120}, PICO_ANCHOR_NW, NULL });
         SDL_PumpEvents();
         Pico_Mouse pos = pico_get_mouse(0);
         assert(pos.x==3 && pos.y==4);


### PR DESCRIPTION
Closes #110

## What this PR does
Adds `pico_warp_mouse(Pico_Rel_Pos* pos)` to move the mouse cursor
programmatically using the same relative coordinate system as
`pico_get_mouse`, supporting `!`, `%`, `#`, and `w` modes.

## Changes
- `src/pico.h` - declared `pico_warp_mouse`
- `src/pico.c` - added `_cv_log_phy` (inverse of `_cv_phy_log`)
  and implemented `pico_warp_mouse` via `SDL_WarpMouseInWindow`
- `lua/pico.c` - extended `l_set_mouse` to accept a table (warp)
  or string (mode), preserving backwards compatibility
- `tst/mouse_warp.c` - new round-trip test: set -> get -> assert
- `lua/tst/mouse_warp.lua` - Lua equivalent of the C test
- `tst/mouse.c`, `tst/tiles.c` - replaced 18 direct
  `SDL_WarpMouseInWindow` calls with `pico_warp_mouse`

## Testing
- Round-trip assertions pass for pixel, percentage, and zoom-offset modes
- Non-trivial coordinates tested: (0.5, 0.5)%, (25, 25)!, (-25, -25)!