### PR TITLE
Fix event starvation when frame deadline is exceeded

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -276,10 +276,17 @@ int pico_input_event (Pico_Event* evt, int type) {
     int now = SDL_GetTicks();
     int cur = (G.expert.t0 + G.expert.ms) - now;
     if (cur <= 0) {
+        // Frame deadline already reached: report it now, instead of
+        // dequeuing a pending event (eg mouse motion, which fires at a much
+        // higher rate than most FPS caps and would otherwise starve NONE
+        // forever while the mouse keeps moving).
         while (G.expert.t0+G.expert.ms <= now) {
             G.expert.t0 += G.expert.ms;
         }
-        cur = 0;
+        if (evt != NULL) {
+            evt->type = PICO_EVENT_NONE;
+        }
+        return 0;
     }
     Pico_Event xevt;
     if (evt == NULL) {


### PR DESCRIPTION
## Summary
When the frame deadline is exceeded, the input event handler now immediately reports a `PICO_EVENT_NONE` event instead of returning 0 with an uninitialized event. This prevents high-frequency events (like mouse motion) from starving the event queue.

## Changes
- Added explanatory comment describing the issue: high-frequency events like mouse motion can starve lower-frequency events when the frame deadline is missed
- Changed behavior when `cur <= 0` (frame deadline reached):
  - Previously: set `cur = 0` and continued to dequeue pending events
  - Now: set `evt->type = PICO_EVENT_NONE` and return 0 immediately
- This ensures that when a frame deadline is exceeded, the application gets a chance to handle the deadline before processing queued input events

## Implementation Details
The fix properly handles the `evt == NULL` case by checking before dereferencing, maintaining safe behavior for all callers.

https://claude.ai/code/session_014GCv3ubbxqcFsgXzYBT4Jf